### PR TITLE
Price Coming Back $0 for Order

### DIFF
--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -129,6 +129,15 @@ class Order(Security):
         details.order_id = input_dict.get('id')
         details.ticker = input_dict.get('underlying-symbol')
         details.price = Decimal(input_dict.get('price', 0))
+
+        # there have been instances where there was no price in dict.
+        if details.price == 0:
+            legs = input_dict.get('legs')
+            if len(legs) > 0:
+                fills = input_dict.get('legs')[0].get('fills')
+                if len(fills) > 0:
+                    details.price = Decimal(input_dict.get('legs')[0].get('fills')[0].get('fill-price'))
+
         details.stop_trigger = Decimal(input_dict.get('stop-trigger', 0))
         details.price_effect = OrderPriceEffect(input_dict.get('price-effect'))
         details.type = OrderType(input_dict.get('order-type'))


### PR DESCRIPTION
# Problem addressed

I found an instance where the price would come back $0 when getting orders. The problem was that there was no instance of 'price' in the input_dict. The price is in the leg[0].fills[0].price. The leg fill is checked if the price is not in input_dict.

# Solution

<!-- Solution description in here -->

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
