### PR TITLE
Add Fill Price to Order Details

### DIFF
--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -140,7 +140,8 @@ class Order(Security):
                 details.fill_price = Decimal(input_dict.get('legs')[0].get('fills')[0].get('fill-price'))
 
         details.stop_trigger = Decimal(input_dict.get('stop-trigger', 0))
-        details.price_effect = OrderPriceEffect(input_dict.get('price-effect'))
+        if input_dict.get('price-effect') != None:
+            details.price_effect = OrderPriceEffect(input_dict.get('price-effect'))
         details.type = OrderType(input_dict.get('order-type'))
         details.status = OrderStatus(input_dict.get('status'))
         details.time_in_force = input_dict.get('time-in-force')
@@ -148,6 +149,10 @@ class Order(Security):
         order = cls(order_details=details)
         for leg in input_dict.get('legs'):
             if leg.get('instrument-type') == 'Equity Option':
+                if leg.get('action') == 'Sell to Close':
+                    details.price_effect = OrderPriceEffect.CREDIT
+                elif leg.get('action') == 'Buy to Open':
+                    details.price_effect = OrderPriceEffect.DEBIT
                 leg_obj = order.get_equity_leg_from_dict(leg)
                 order.details.legs.append(leg_obj)
         return order

--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -55,6 +55,7 @@ class OrderDetails(object):
     time_in_force: TimeInForce = TimeInForce.DAY
     gtc_date: datetime = None
     price: Decimal = None
+    fill_price: Decimal = None
     stop_trigger: Decimal = None
     price_effect: OrderPriceEffect = None
     status: OrderStatus = None
@@ -129,14 +130,14 @@ class Order(Security):
         details.order_id = input_dict.get('id')
         details.ticker = input_dict.get('underlying-symbol')
         details.price = Decimal(input_dict.get('price', 0))
-
+        details.fill_price = Decimal('0')
+        
         # there have been instances where there was no price in dict.
-        if details.price == 0:
-            legs = input_dict.get('legs')
-            if len(legs) > 0:
-                fills = input_dict.get('legs')[0].get('fills')
-                if len(fills) > 0:
-                    details.price = Decimal(input_dict.get('legs')[0].get('fills')[0].get('fill-price'))
+        legs = input_dict.get('legs')
+        if len(legs) > 0:
+            fills = input_dict.get('legs')[0].get('fills')
+            if len(fills) > 0:
+                details.fill_price = Decimal(input_dict.get('legs')[0].get('fills')[0].get('fill-price'))
 
         details.stop_trigger = Decimal(input_dict.get('stop-trigger', 0))
         details.price_effect = OrderPriceEffect(input_dict.get('price-effect'))

--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -129,6 +129,15 @@ class Order(Security):
         details.order_id = input_dict.get('id')
         details.ticker = input_dict.get('underlying-symbol')
         details.price = Decimal(input_dict.get('price', 0))
+
+        # there have been instances where there was no price in dict.
+        if details.price == 0:
+            legs = input_dict.get('legs')
+            if len(legs) > 0:
+                fills = input_dict.get('legs')[0].get('fills')
+                if len(fills) > 0:
+                    details.price = Decimal(input_dict.get('legs')[0].get('fills')[0].get('fill-price'))
+
         details.stop_trigger = Decimal(input_dict.get('stop-trigger', 0))
         details.price_effect = OrderPriceEffect(input_dict.get('price-effect'))
         details.type = OrderType(input_dict.get('order-type'))


### PR DESCRIPTION
# Problem addressed
Fill price is missing from the order details.

# Solution
Add fill price.

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
